### PR TITLE
fix: explicitly declare stored property to get rid of warning

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -20,6 +20,8 @@
 if (!defined('DOKU_INC')) die();
 
 class syntax_plugin_ifday extends DokuWiki_Syntax_Plugin {
+    //** cached plugin configuration */
+    protected ?array $conf = null;
 
     /** @var bool Whether to show errors visibly on the wiki page */
     protected $showErrors = true;


### PR DESCRIPTION
fixes #3 