### PR TITLE
build: fixed issue with plugin.info.txt not using tabs

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
-base   ifday
-author dWiGhT Mulcahy
-email  dWiGhT.Codes@gmail.com
-date   2025-08-14
-name   IfDay Plugin
-desc   Enables <ifday> syntax for conditional display based on weekday, weekend, day names, with complex logic and parentheses
-url    http://www.dokuwiki.org/plugin:ifday
+base	ifday
+author	dWiGhT Mulcahy
+email	dWiGhT.Codes@gmail.com
+date	2025-08-14
+name	IfDay Plugin
+desc	Enables ifday syntax for conditional display based on weekday, weekend, day names, with complex logic and parentheses
+url	https://www.dokuwiki.org/plugin:ifday


### PR DESCRIPTION
seems that Dokuwiki extension crawler requires the use of TABS in the plugin.info.txt file