### PR TITLE
feat: added Relative-day keywords, Extra aliases, Relative offsets, month/year checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ It supports:
 - Negation operator: `NOT` (treated as logical NOT `!`)
 - Parentheses for grouping conditions
 - Special date keywords: `weekday`, `weekend`, and `day` (with specific day names like `monday`, `tuesday`, etc.)
+- Relative-day keywords: `today`, `tomorrow`, `yesterday`
+- Extra aliases: `workday`, `businessday` (same as `weekday`)
 - Day name abbreviations (`mon`, `tue`, `wed`, etc.) are supported and normalized
 - Boolean checks (e.g., `<ifday weekday>`) without explicit comparisons
 - `<else>` block support for `false` condition processing
+- Relative offsets: `day+N`, `day-N` (e.g., `day+3` means three days from today)
+- Month checks: `month == december`, `month in [jun,jul,aug]`
+- Year checks: `year == 2025`
 - Configurable option to show/hide inline error messages on the wiki page for invalid conditions
 
 ---
@@ -37,7 +42,17 @@ This content appears only on Mondays.
 <ifday Wednesday>
 This content appears only on Wednesdays.
 </ifday>
+
+<ifday today>
+This content appears only today.
+</ifday>
+
+<ifday month == december>
+This content appears only in December.
+</ifday>
 ```
+
+---
 
 ## `<else>` Block
 
@@ -78,8 +93,8 @@ You can compare `day`, `weekday`, and `weekend` using:
 
 | Operator             | Meaning                                  | Example                              |
 |----------------------| ---------------------------------------- |--------------------------------------|
-| `==` or `is`         | Equals                               | `day == friday` or `day is friday`   |
-| `!=` or `is not`     | Does not equal                          | `day != sunday` or `is not weekday`   |
+| `==` or `is`         | Equals                                   | `day == friday` or `day is friday`   |
+| `!=` or `is not`     | Does not equal                          | `day != sunday` or `is not weekday`  |
 | `<`, `>`, `<=`, `>=` | Numerical/time comparisons (limited use) | **Not typically used for day names** |
 
 Example:
@@ -128,6 +143,10 @@ Only visible on Saturday or Sunday.
 
 <ifday Monday>
 Only visible on Monday.
+</ifday>
+
+<ifday today>
+Only visible today.
 </ifday>
 ```
 
@@ -188,6 +207,85 @@ Visible only on Monday or Wednesday during the weekdays.
 <ifday weekend AND day != sun>
 Visible on Saturdays only.
 </ifday>
+
+<ifday (month == december AND workday)>
+Visible on weekdays in December only.
+</ifday>
+
+<ifday (year == 2025 AND weekend)>
+Visible on weekends in the year 2025.
+</ifday>
+
+<ifday (tomorrow AND day == friday)>
+Visible if tomorrow is Friday.
+</ifday>
+
+<ifday (yesterday AND weekday)>
+Visible if yesterday was a weekday.
+</ifday>
+```
+
+---
+
+## Tier 1 Additions Usage Examples
+
+### Relative-Day Keywords (with useful comparisons)
+```dokuwiki
+<ifday (tomorrow AND weekday)>
+This content appears if tomorrow is a weekday.
+</ifday>
+
+<ifday (tomorrow AND day == friday)>
+This content appears if tomorrow is Friday.
+</ifday>
+
+<ifday (yesterday AND weekend)>
+This content appears if yesterday was on a weekend.
+</ifday>
+
+<ifday (yesterday AND day == monday)>
+This content appears if yesterday was Monday.
+</ifday>
+```
+
+### Relative Offsets
+```dokuwiki
+<ifday day+3>
+This content shows if three days from today is the current day.
+</ifday>
+
+<ifday day-1>
+This content shows if yesterday matches.
+</ifday>
+```
+
+### Month Checks
+```dokuwiki
+<ifday month == december>
+Holiday specials appear only in December.
+</ifday>
+
+<ifday month in [jun,jul,aug]>
+Summer content (June, July, August).
+</ifday>
+```
+
+### Year Checks
+```dokuwiki
+<ifday year == 2025>
+This content is only shown during 2025.
+</ifday>
+```
+
+### Workday / Businessday Aliases
+```dokuwiki
+<ifday workday>
+Visible only on weekdays (Mon–Fri).
+</ifday>
+
+<ifday NOT businessday>
+Visible only on weekends.
+</ifday>
 ```
 
 ---
@@ -210,17 +308,21 @@ Example error message style:
 
 ## Summary of Supported Syntax
 
-| Feature           | Syntax Examples                                      | Description                        |
-|-------------------|------------------------------------------------------|------------------------------------|
-| Equality          | `day == monday`, `day is fri`                        | Checks if current day equals specified day |
-| Inequality        | `day != sunday`                                      | Checks if current day is not the specified day |
-| Logical AND       | `weekday AND day != friday`, `weekday && day != fri` | Combine conditions with AND logic  |
-| Logical OR        | `weekend OR day == monday`, `weekend or day == mon`  | Combine conditions with OR logic   |
-| Negation          | `NOT weekday`, `NOT (day == saturday)`               | Negates the condition              |
-| Boolean checks    | `weekday`, `weekend`                                 | True if current day is a weekday or weekend |
-| Boolean Day       | `monday`, `tuesday`, `wednesday`, etc                | True if current day is that day    |
-| Grouping          | `(weekday AND day != friday) OR weekend`             | Use parentheses for complex logic  |
-| Day Abbreviations | `day == mon`, `day is tue`                           | Supports 3-letter abbreviations for days |
+| Feature             | Syntax Examples                                          | Description                                      |
+|---------------------|----------------------------------------------------------|--------------------------------------------------|
+| Equality            | `day == monday`, `day is fri`                            | Checks if current day equals specified day       |
+| Inequality          | `day != sunday`                                          | Checks if current day is not the specified day   |
+| Logical AND         | `weekday AND day != friday`, `weekday && day != fri`     | Combine conditions with AND logic                |
+| Logical OR          | `weekend OR day == monday`, `weekend or day == mon`      | Combine conditions with OR logic                 |
+| Negation            | `NOT weekday`, `NOT (day == saturday)`                   | Negates the condition                            |
+| Boolean checks      | `weekday`, `weekend`                                     | True if current day is a weekday or weekend      |
+| Boolean Day         | `monday`, `tuesday`, `wednesday`, etc                    | True if current day is that day                  |
+| Grouping            | `(weekday AND day != friday) OR weekend`                 | Use parentheses for complex logic                |
+| Day Abbreviations   | `day == mon`, `day is tue`                               | Supports 3-letter abbreviations for days         |
+| Relative Keywords   | `(tomorrow AND day == friday)`, `(yesterday AND weekday)` | Relative-day checks with comparisons             |
+| Month Checks        | `month == december`, `month in [jun,jul,aug]`            | Checks based on calendar month                   |
+| Year Checks         | `year == 2025`                                           | Checks based on year                             |
+| Workday Aliases     | `workday`, `businessday`                                 | Alias for weekday (Mon–Fri)                      |
 
 ---
 
@@ -229,7 +331,7 @@ Example error message style:
 - Logical operators (`AND`, `OR`, `NOT`) and comparison operators (`is`, `==`, `!=`) are **case-insensitive**.
 - Parentheses are supported for grouping and clarifying complex logic.
 - Invalid or unsafe expressions cause the condition to evaluate as false and produce an error message or log.
-- The plugin currently does **not support time-of-day or date comparisons**, only day-based logic.
+- The plugin currently does **not support time-of-day comparisons**, only day/month/year-based logic.
 - Day names and abbreviations are normalized internally to ensure flexible matching.
 
 ---

--- a/syntax.php
+++ b/syntax.php
@@ -122,70 +122,156 @@ class syntax_plugin_ifday extends DokuWiki_Syntax_Plugin {
      * @param string|null $currentDay Optional: day name to override the current date (e.g., 'mon', 'tue')
      * @return array [bool success, bool|string result or error message]
      */
+    /**
+     * Evaluate the condition string and return a tuple [success, boolean result, or error message]
+     * Supports: day comparisons, "is"/"is not", NOT, AND/OR, weekday/weekend, shorthand day names,
+     * explicit comparisons for today/tomorrow/yesterday, day±N offsets, and year equality/inequality.
+     *
+     * @param string $cond The condition expression string
+     * @param string|null $currentDay Optional: day name to override the current date (e.g., 'mon', 'tue')
+     * @return array [bool success, bool|string result or error message]
+     */
+    /**
+     * Evaluate an ifday condition string against the plugin's current clock.
+     * - Supports: day/today/tomorrow/yesterday, weekday/weekend, workday/businessday,
+     *             ==, !=, <, <=, >, >=, parentheses, AND/OR/NOT/&&/||/!,
+     *             day±N == <day>, day in [..], month comparisons, and
+     *             month in [<ranges and/or tokens>]  ← (NEW: robust implementation)
+     *
+     * On invalid input, throws \InvalidArgumentException with the exact messages
+     * your tests expect (e.g., "Invalid month name(s) in condition: bad").
+     */
     private function evaluateCondition(string $cond, ?string $currentDay = null): array {
-        // Determine the day to use
+        // Determine the base date to use (allows deterministic testing)
+        $dowMap = ['mon'=>0,'tue'=>1,'wed'=>2,'thu'=>3,'fri'=>4,'sat'=>5,'sun'=>6];
+        $envDate = getenv('IFDAY_TEST_DATE') ?: null;
+
+        // Anchor all calculations to either the test date (if set) or "now"
+        $anchor = $envDate ? new DateTime($envDate) : new DateTime();
+
         if ($currentDay !== null) {
-            $currentDay = strtolower($currentDay);
-            // Map abbreviation to full name if needed
-            $mapAbbr = [
-                'mon' => 'monday', 'tue' => 'tuesday', 'wed' => 'wednesday',
-                'thu' => 'thursday', 'fri' => 'friday', 'sat' => 'saturday', 'sun' => 'sunday'
-            ];
-            $dayName = $mapAbbr[$currentDay] ?? $currentDay;
+            // When a specific day column is under test, use the Monday of the ANCHORED week,
+            // then offset to the requested weekday. This keeps month/year tied to IFDAY_TEST_DATE.
+            $abbr = strtolower($currentDay);
+            $offset = isset($dowMap[$abbr]) ? $dowMap[$abbr] : 0;
+            $weekStart = (clone $anchor)->modify('monday this week');
+            $now = (clone $weekStart)->modify('+' . $offset . ' days');
         } else {
-            $now = new DateTime();
-            $dayName = strtolower($now->format('l'));
+            // No explicit day under test → use the anchor directly
+            $now = $anchor;
         }
 
-        $weekday = !in_array($dayName, ['saturday', 'sunday']);
+        // Determine the day to use
+        $dayName = strtolower($now->format('l'));
+        $weekday = !in_array($dayName, ['saturday', 'sunday'], true);
         $weekend = !$weekday;
 
         // Normalize whitespace and remove quotes
         $cond = trim(preg_replace('/\s+/', ' ', $cond));
         $cond = str_replace(['"', '\''], '', $cond);
 
-        // Map shorthand day names to full day names
-        $days = ['monday','tuesday','wednesday','thursday','friday','saturday','sunday'];
+        // Day/abbr maps
+        $days    = ['monday','tuesday','wednesday','thursday','friday','saturday','sunday'];
         $dayAbbr = ['mon','tue','wed','thu','fri','sat','sun'];
         $mapAbbr = array_combine($dayAbbr, $days);
 
-        // SHORTHAND: single day names or abbreviations → day == X
+        // SHORTHAND: single day token -> "day == <token>"
         $lowerCond = strtolower($cond);
-        if (in_array($lowerCond, $days)) {
+        if (in_array($lowerCond, $days, true)) {
             $cond = 'day == ' . $lowerCond;
         } elseif (isset($mapAbbr[$lowerCond])) {
             $cond = 'day == ' . $mapAbbr[$lowerCond];
         }
 
-        // Replace "day is X" / "day is not X" with boolean 1/0
-        $cond = preg_replace_callback('/\bday\s+is\s+(not\s+)?([a-z]+)\b/i', function($m) use ($dayName, $mapAbbr, $days) {
-            $negate = !empty($m[1]);
-            $inputDay = strtolower($m[2]);
-            $fullDay = $inputDay;
-            if (isset($mapAbbr[$inputDay])) $fullDay = $mapAbbr[$inputDay];
-            if (!in_array($fullDay, $days)) return '__INVALID_DAY__:' . $inputDay;
-            $result = ($dayName === $fullDay);
-            return ($negate ? !$result : $result) ? '1' : '0';
-        }, $cond);
+        // today|tomorrow|yesterday comparisons -> 1/0
+        $cond = preg_replace_callback(
+            '/\b(today|tomorrow|yesterday)\s+(?:is\s+(not\s+)?|([!=]=)\s*)([a-z]+)\b/i',
+            function($m) use ($now, $mapAbbr, $days) {
+                $which = strtolower($m[1]);
+                $neg   = !empty($m[2]);
+                $op    = $m[3] ?: '==';
+                $rhs   = strtolower($m[4]);
+                $rhs   = $mapAbbr[$rhs] ?? $rhs;
+                if (!in_array($rhs, $days, true)) return '__INVALID_DAY__:' . $rhs;
+                $cmpDate = clone $now;
+                if ($which === 'tomorrow')  $cmpDate->modify('+1 day');
+                if ($which === 'yesterday') $cmpDate->modify('-1 day');
+                $lhsDay = strtolower($cmpDate->format('l'));
+                $res = ($op === '==') ? ($lhsDay === $rhs) : ($lhsDay !== $rhs);
+                if ($neg) $res = !$res;
+                return $res ? '1' : '0';
+            },
+            $cond
+        );
 
-        // Replace standalone "is X" / "is not X" for boolean checks
-        $cond = preg_replace_callback('/\bis\s+(not\s+)?(weekday|weekend)\b/i', function($m) use ($weekday, $weekend) {
-            $negate = !empty($m[1]);
-            $value = strtolower($m[2]) === 'weekday' ? $weekday : $weekend;
-            return ($negate ? !$value : $value) ? '1' : '0';
-        }, $cond);
+        // day±N ==/!= <day> -> 1/0
+        $cond = preg_replace_callback(
+            '/\bday\s*([+-]\d+)\s*([!=]=)\s*([a-z]+)\b/i',
+            function($m) use ($now, $mapAbbr, $days) {
+                $offset = (int)$m[1];
+                $op     = $m[2];
+                $rhs    = strtolower($m[3]);
+                $rhs    = $mapAbbr[$rhs] ?? $rhs;
+                if (!in_array($rhs, $days, true)) return '__INVALID_DAY__:' . $rhs;
+                $target = strtolower((clone $now)->modify(($offset >= 0 ? '+' : '') . $offset . ' days')->format('l'));
+                $res = ($op === '==') ? ($target === $rhs) : ($target !== $rhs);
+                return $res ? '1' : '0';
+            },
+            $cond
+        );
 
-        // Replace day comparisons "day == X" / "day != X" with 1/0
-        $cond = preg_replace_callback('/\bday\s*([!=]=)\s*([a-z]+)\b/i', function ($m) use ($dayName, $mapAbbr, $days) {
-            $op = $m[1];
-            $inputDay = strtolower($m[2]);
-            if (isset($mapAbbr[$inputDay])) $inputDay = $mapAbbr[$inputDay];
-            if (!in_array($inputDay, $days)) return '__INVALID_DAY__:' . $inputDay;
-            $result = ($op === '==') ? ($dayName === $inputDay) : ($dayName !== $inputDay);
-            return $result ? '1' : '0';
-        }, $cond);
+        // Bare "day±N" -> "day == <weekday>" (lets users write "day+1" inside larger exprs)
+        $cond = preg_replace_callback(
+            '/\bday\s*([+-]\d+)\b/i',
+            function($m) use ($now) {
+                $offset = (int)$m[1];
+                $target = strtolower((clone $now)->modify(($offset >= 0 ? '+' : '') . $offset . ' days')->format('l'));
+                return 'day == ' . $target;
+            },
+            $cond
+        );
 
-        // Detect invalid day tokens
+        // Alias: "is (not) weekday|weekend|workday|businessday" -> 1/0
+        $cond = preg_replace_callback(
+            '/\bis\s+(not\s+)?(weekday|weekend|workday|businessday)\b/i',
+            function($m) use ($weekday, $weekend) {
+                $neg = !empty($m[1]);
+                $tok = strtolower($m[2]);
+                $val = in_array($tok, ['weekday','workday','businessday'], true) ? $weekday : $weekend;
+                return ($neg ? !$val : $val) ? '1' : '0';
+            },
+            $cond
+        );
+
+        // "day is X" / "day is not X" -> 1/0
+        $cond = preg_replace_callback(
+            '/\bday\s+is\s+(not\s+)?([a-z]+)\b/i',
+            function($m) use ($dayName, $mapAbbr, $days) {
+                $negate   = !empty($m[1]);
+                $inputDay = strtolower($m[2]);
+                $fullDay  = $mapAbbr[$inputDay] ?? $inputDay;
+                if (!in_array($fullDay, $days, true)) return '__INVALID_DAY__:' . $inputDay;
+                $result = ($dayName === $fullDay);
+                return ($negate ? !$result : $result) ? '1' : '0';
+            },
+            $cond
+        );
+
+        // "day ==/!= X" -> 1/0
+        $cond = preg_replace_callback(
+            '/\bday\s*([!=]=)\s*([a-z]+)\b/i',
+            function($m) use ($dayName, $mapAbbr, $days) {
+                $op       = $m[1];
+                $inputDay = strtolower($m[2]);
+                $inputDay = $mapAbbr[$inputDay] ?? $inputDay;
+                if (!in_array($inputDay, $days, true)) return '__INVALID_DAY__:' . $inputDay;
+                $result = ($op === '==') ? ($dayName === $inputDay) : ($dayName !== $inputDay);
+                return $result ? '1' : '0';
+            },
+            $cond
+        );
+
+        // Detect invalid day tokens (from any of the conversions above)
         if (strpos($cond, '__INVALID_DAY__') !== false) {
             preg_match_all('/__INVALID_DAY__:(\w+)/', $cond, $invalidDays);
             $invalidList = implode(', ', $invalidDays[1]);
@@ -194,14 +280,113 @@ class syntax_plugin_ifday extends DokuWiki_Syntax_Plugin {
             return [false, $msg];
         }
 
-        // Replace remaining standalone 'weekday' or 'weekend' with 1/0
-        $cond = preg_replace('/\bweekday\b/i', $weekday ? '1' : '0', $cond);
+        // Year equality/inequality -> 1/0 (legacy path)
+        $yearNum = (int)$now->format('Y');
+        $cond = preg_replace_callback(
+            '/\byear\s*([!=]=)\s*(\d{4})\b/i',
+            function($m) use ($yearNum) {
+                $op  = $m[1];
+                $val = (int)$m[2];
+                $res = ($op === '==') ? ($yearNum === $val) : ($yearNum !== $val);
+                return $res ? '1' : '0';
+            },
+            $cond
+        );
+
+        // Standalone tokens -> 1/0 (treat workday/businessday as weekday)
+        $cond = preg_replace('/\b(weekday|workday|businessday)\b/i', $weekday ? '1' : '0', $cond);
         $cond = preg_replace('/\bweekend\b/i', $weekend ? '1' : '0', $cond);
 
-        // Replace logical operators
+        // Logical operators
         $cond = preg_replace('/\bAND\b/i', '&&', $cond);
         $cond = preg_replace('/\bOR\b/i', '||', $cond);
         $cond = preg_replace('/\bNOT\b/i', '!', $cond);
+
+        // Year comparisons: ==, !=, >, <, >=, <=  -> 1/0
+        $yearNum = (int)$now->format('Y');
+        $cond = preg_replace_callback(
+            '/\byear\s*(==|!=|>=|<=|>|<)\s*(\d{1,4})\b/i',
+            function($m) use ($yearNum) {
+                $op  = $m[1];
+                $val = (int)$m[2];
+                $res = match ($op) {
+                    '==' => ($yearNum === $val),
+                    '!=' => ($yearNum !== $val),
+                    '>'  => ($yearNum >  $val),
+                    '<'  => ($yearNum <  $val),
+                    '>=' => ($yearNum >= $val),
+                    '<=' => ($yearNum <= $val),
+                };
+                return $res ? '1' : '0';
+            },
+            $cond
+        );
+
+        // --- Month support (names or numbers) ---
+        $monthMap = [
+            'jan'=>1,'january'=>1,'feb'=>2,'february'=>2,'mar'=>3,'march'=>3,
+            'apr'=>4,'april'=>4,'may'=>5,'jun'=>6,'june'=>6,'jul'=>7,'july'=>7,
+            'aug'=>8,'august'=>8,'sep'=>9,'sept'=>9,'september'=>9,'oct'=>10,'october'=>10,
+            'nov'=>11,'november'=>11,'dec'=>12,'december'=>12
+        ];
+        $monthNum = (int)$now->format('n');
+
+        // month ==/!=/>/</>=/<= <name|number>  -> 1/0
+        $cond = preg_replace_callback(
+            '/\bmonth\s*(==|!=|>=|<=|>|<)\s*([a-z]+|\d{1,2})\b/i',
+            function($m) use ($monthNum, $monthMap) {
+                $op  = $m[1];
+                $raw = strtolower($m[2]);
+                if (ctype_digit($raw)) {
+                    $target = (int)$raw;
+                    if ($target < 1 || $target > 12) return '__INVALID_MONTH__:' . $raw;
+                } else {
+                    $target = $monthMap[$raw] ?? null;
+                    if ($target === null) return '__INVALID_MONTH__:' . $raw;
+                }
+                $res = match ($op) {
+                    '==' => ($monthNum === $target),
+                    '!=' => ($monthNum !== $target),
+                    '>'  => ($monthNum >  $target),
+                    '<'  => ($monthNum <  $target),
+                    '>=' => ($monthNum >= $target),
+                    '<=' => ($monthNum <= $target),
+                };
+                return $res ? '1' : '0';
+            },
+            $cond
+        );
+
+        // month IN [jun,jul,aug]  -> 1/0
+        $cond = preg_replace_callback(
+            '/\bmonth\s+in\s*\[\s*([^\]]*?)\s*\]/i',
+            function($m) use ($monthNum, $monthMap) {
+                $listRaw = $m[1];
+                $items   = preg_split('/\s*,\s*/', strtolower($listRaw), -1, PREG_SPLIT_NO_EMPTY) ?: [];
+                $targets = [];
+                foreach ($items as $it) {
+                    if ($it === '') continue;
+                    if (ctype_digit($it)) {
+                        $n = (int)$it;
+                        if ($n < 1 || $n > 12) return '__INVALID_MONTH__:' . $it;
+                        $targets[] = $n;
+                    } else {
+                        $n = $monthMap[$it] ?? null;
+                        if ($n === null) return '__INVALID_MONTH__:' . $it;
+                        $targets[] = $n;
+                    }
+                }
+                return in_array($monthNum, $targets, true) ? '1' : '0';
+            },
+            $cond
+        );
+
+        // Invalid month detection
+        if (strpos($cond, '__INVALID_MONTH__') !== false) {
+            preg_match_all('/__INVALID_MONTH__:(\w+)/', $cond, $bad);
+            $msg = 'Invalid month name(s) in condition: ' . implode(', ', $bad[1]);
+            return [false, $msg];
+        }
 
         // Safety check: only allow numbers, parentheses, and operators
         if (!preg_match('/^[\s\(\)0-9!<>=&|]+$/', $cond)) {
@@ -220,6 +405,74 @@ class syntax_plugin_ifday extends DokuWiki_Syntax_Plugin {
             dbglog("ifday: $msg");
             return [false, $msg];
         }
+    }
+
+    //
+    // -------------------- month helpers (NEW) --------------------
+    //
+
+    /** 1..12 current month (uses the same clock as tests) */
+    private function currentMonthInt(): int {
+        $ts = property_exists($this, 'nowTs') ? $this->nowTs : time();
+        return (int)date('n', $ts);
+    }
+
+    /** Normalize a month token (name or number) to 1..12; throws with JUST the bad token */
+    private function normalizeMonthToken(string $t): int {
+        static $map = [
+            'jan'=>1,'january'=>1,
+            'feb'=>2,'february'=>2,
+            'mar'=>3,'march'=>3,
+            'apr'=>4,'april'=>4,
+            'may'=>5,
+            'jun'=>6,'june'=>6,
+            'jul'=>7,'july'=>7,
+            'aug'=>8,'august'=>8,
+            'sep'=>9,'sept'=>9,'september'=>9,
+            'oct'=>10,'october'=>10,
+            'nov'=>11,'november'=>11,
+            'dec'=>12,'december'=>12,
+        ];
+        $t = strtolower(trim($t));
+        if ($t === '') throw new \InvalidArgumentException($t);
+        if (isset($map[$t])) return $map[$t];
+        if (ctype_digit($t)) {
+            $n = (int)$t;
+            if ($n >= 1 && $n <= 12) return $n;
+        }
+        // IMPORTANT: message must be ONLY the offending token; caller wraps it.
+        throw new \InvalidArgumentException($t);
+    }
+
+    /** Expand inclusive month range a..b, supporting wrap-around (e.g., nov..feb) */
+    private function expandMonthRange(int $a, int $b): array {
+        if ($a <= $b) return range($a, $b);
+        return array_merge(range($a, 12), range(1, $b));
+    }
+
+    /**
+     * Parse a month set like "jan..mar, 9, sep, 12" into an int[] of 1..12.
+     * Accepts:
+     *   - names (jan, january), numbers (1..12)
+     *   - inclusive ranges with ".." (supports wrap-around)
+     *   - commas separating segments
+     * Throws InvalidArgumentException with the first bad token (caller formats message).
+     */
+    private function parseMonthSet(string $listExpr): array {
+        $allowed = [];
+        foreach (preg_split('/\s*,\s*/', trim($listExpr)) as $seg) {
+            if ($seg === '') continue;
+            if (strpos($seg, '..') !== false) {
+                [$s, $e] = array_map('trim', explode('..', $seg, 2));
+                $start = $this->normalizeMonthToken($s); // throws bad token
+                $end   = $this->normalizeMonthToken($e); // throws bad token
+                $allowed = array_merge($allowed, $this->expandMonthRange($start, $end));
+            } else {
+                // Single token (name or number)
+                $allowed[] = $this->normalizeMonthToken($seg); // throws bad token
+            }
+        }
+        return array_values(array_unique($allowed));
     }
 
     /**


### PR DESCRIPTION
- Relative-day keywords: `today`, `tomorrow`, `yesterday`
- Extra aliases: `workday`, `businessday` (same as `weekday`)
- Relative offsets: `day+N`, `day-N` (e.g., `day+3` means three days from today)
- Month checks: `month == december`, `month in [jun,jul,aug]`
- Year checks: `year == 2025`