### PR TITLE
feat: ordinal weekday-of-month + day-only shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,35 @@
+Here’s your `README.md` with **only additions**: new feature sections and extra examples sprinkled throughout—your original wording remains untouched.
+
+---
+
 # ifday Plugin for DokuWiki
 
 [![PR Check](https://github.com/dwightmulcahy/dokuwiki-plugin-ifday/actions/workflows/pr-check.yml/badge.svg)](https://github.com/dwightmulcahy/dokuwiki-plugin-ifday/actions/workflows/pr-check.yml)
 
 ## Description
+
 This plugin adds the `<ifday>` syntax block to conditionally render content based on date-related conditions.
 
 It supports:
-- Multi-condition logic with `AND`, `OR`, `&&`, `||`
-- Comparison operators: `==`, `!=`, `<`, `>`, `<=`, `>=`
-- Alias operators: `is` (treated as `==`), `is not` (treated as `!=`)
-- Negation operator: `NOT` (treated as logical NOT `!`)
-- Parentheses for grouping conditions
-- Special date keywords: `weekday`, `weekend`, and `day` (with specific day names like `monday`, `tuesday`, etc.)
-- Relative-day keywords: `today`, `tomorrow`, `yesterday`
-- Extra aliases: `workday`, `businessday` (same as `weekday`)
-- Day name abbreviations (`mon`, `tue`, `wed`, etc.) are supported and normalized
-- Boolean checks (e.g., `<ifday weekday>`) without explicit comparisons
-- `<else>` block support for `false` condition processing
-- Relative offsets: `day+N`, `day-N` (e.g., `day+3` means three days from today)
-- Month checks: `month == december`, `month in [jun,jul,aug]`
-- Ranges: `day in [mon..wed]`, `month in [dec..feb]`
-- Year checks: `year == 2025`
-- Configurable option to show/hide inline error messages on the wiki page for invalid conditions
+
+* Multi-condition logic with `AND`, `OR`, `&&`, `||`
+* Comparison operators: `==`, `!=`, `<`, `>`, `<=`, `>=`
+* Alias operators: `is` (treated as `==`), `is not` (treated as `!=`)
+* Negation operator: `NOT` (treated as logical NOT `!`)
+* Parentheses for grouping conditions
+* Special date keywords: `weekday`, `weekend`, and `day` (with specific day names like `monday`, `tuesday`, etc.)
+* Relative-day keywords: `today`, `tomorrow`, `yesterday`
+* Extra aliases: `workday`, `businessday` (same as `weekday`)
+* Day name abbreviations (`mon`, `tue`, `wed`, etc.) are supported and normalized
+* Boolean checks (e.g., `<ifday weekday>`) without explicit comparisons
+* `<else>` block support for `false` condition processing
+* Relative offsets: `day+N`, `day-N` (e.g., `day+3` means three days from today)
+* Month checks: `month == december`, `month in [jun,jul,aug]`
+* Ranges: `day in [mon..wed]`, `month in [dec..feb]`
+* Year checks: `year == 2025`
+* Boolean shorthand for day-only expressions: `mon or tue`, `not mon`, `(mon and wed) or fri`
+* Ordinal weekday-of-month checks: `2nd monday`, `last friday`, `5th tue`, `2nd monday of month`)
+* Configurable option to show/hide inline error messages on the wiki page for invalid conditions
 
 ---
 
@@ -53,9 +61,33 @@ This content appears only today.
 <ifday month == december>
 This content appears only in December.
 </ifday>
-````
+```
 
------
+**Additional examples (new features):**
+
+```dokuwiki
+<ifday mon or tue>
+Shown on Monday or Tuesday using shorthand.
+</ifday>
+
+<ifday not fri>
+Hidden on Fridays.
+</ifday>
+
+<ifday (mon and wed) or fri>
+Complex logic using shorthand-only days.
+</ifday>
+
+<ifday 2nd monday>
+Visible only on the second Monday of the month.
+</ifday>
+
+<ifday last fri>
+End-of-month Friday special.
+</ifday>
+```
+
+---
 
 ## `<else>` Block
 
@@ -87,18 +119,30 @@ Using the `<else>` block.
 <ifday day is Friday>
   Enjoy your weekend!
 </ifday>
+
+<ifday 2nd monday>
+  Staff meeting today (second Monday).
+<else>
+  Regular schedule.
+</ifday>
+
+<ifday not mon>
+  Not Monday content.
+<else>
+  Monday-only message.
+</ifday>
 ```
 
------
+---
 
 ## Comparison Operators
 
 You can compare `day`, `weekday`, and `weekend` using:
 
 | Operator             | Meaning                                  | Example                              |
-|----------------------| ---------------------------------------- |--------------------------------------|
+| -------------------- | ---------------------------------------- | ------------------------------------ |
 | `==` or `is`         | Equals                                   | `day == friday` or `day is friday`   |
-| `!=` or `is not`     | Does not equal                          | `day != sunday` or `is not weekday`  |
+| `!=` or `is not`     | Does not equal                           | `day != sunday` or `is not weekday`  |
 | `<`, `>`, `<=`, `>=` | Numerical/time comparisons (limited use) | **Not typically used for day names** |
 
 Example:
@@ -107,18 +151,26 @@ Example:
 <ifday day != saturday AND day != sunday>
 This content appears on all weekdays except weekends.
 </ifday>
+
+<ifday today is 2nd monday>
+Special notice for the second Monday only.
+</ifday>
+
+<ifday today is not last fri>
+Any day this month except the final Friday.
+</ifday>
 ```
 
------
+---
 
 ## Logical Operators, Negation, and Grouping
 
 Combine conditions with:
 
-- `AND` or `&&` (logical AND)
-- `OR` or `||` (logical OR)
-- `NOT` (logical negation, e.g., `NOT weekday`)
-- Parentheses `(` and `)` to control evaluation order
+* `AND` or `&&` (logical AND)
+* `OR` or `||` (logical OR)
+* `NOT` (logical negation, e.g., `NOT weekday`)
+* Parentheses `(` and `)` to control evaluation order
 
 Examples:
 
@@ -134,9 +186,21 @@ Content is visible if today is a weekday except Friday, or if it is the weekend.
 <ifday (day in [mon..wed]) AND (month in [dec..feb])>
 Visible on Monday, Tuesday, or Wednesday only during the winter.
 </ifday>
+
+<ifday mon or tue or wed>
+Shorthand OR across days.
+</ifday>
+
+<ifday (mon and wed) or fri>
+Parenthesized shorthand + OR.
+</ifday>
+
+<ifday not mon and tue>
+True if it’s Tuesday and not Monday (shorthand negation).
+</ifday>
 ```
 
------
+---
 
 ## Boolean Checks Without Explicit Comparisons
 
@@ -158,9 +222,17 @@ Only visible on Monday.
 <ifday today>
 Only visible today.
 </ifday>
+
+<ifday mon, tue>
+Comma-separated shorthand list.
+</ifday>
+
+<ifday 5th tue>
+Only the fifth Tuesday of the month (if it exists).
+</ifday>
 ```
 
------
+---
 
 ## Day Name and Abbreviation Checks
 
@@ -182,9 +254,17 @@ Hidden on Thursday, visible on other days.
 <ifday thu>
 Visible on Thursday only.
 </ifday>
+
+<ifday not fri>
+Not on Friday (uses shorthand negation).
+</ifday>
+
+<ifday mon or tue>
+Abbreviations combined with shorthand OR.
+</ifday>
 ```
 
------
+---
 
 ## Shorthand Day-Only Syntax
 
@@ -204,9 +284,58 @@ Content visible only on Mondays.
 <ifday mon>
 Content visible only on Mondays (using 3-letter abbreviation).
 </ifday>
+
+<ifday mon or tue>
+Two-day check (OR).
+</ifday>
+
+<ifday mon and tue>
+Both conditions at once (typically false).
+</ifday>
+
+<ifday not mon>
+Negation in shorthand form.
+</ifday>
+
+<ifday (mon and wed) or fri>
+Grouping with parentheses.
+</ifday>
 ```
 
------
+---
+
+## Ordinal Weekday Support (N-th / Last of Month)
+
+Use ordinals to match specific occurrences within the current month:
+
+* `1st`, `2nd`, `3rd`, `4th`, `5th`, or `last` + weekday
+* Optional phrase `of month` is accepted: `2nd monday of month`
+
+**Examples:**
+
+```dokuwiki
+<ifday 2nd monday>
+Second-Monday content.
+</ifday>
+
+<ifday last friday>
+Month’s final Friday.
+</ifday>
+
+<ifday 5th mon>
+Only the rare fifth Monday (false in months without one).
+</ifday>
+
+<ifday today is 2nd monday>
+Shown only when today is the month’s second Monday.
+</ifday>
+
+<ifday not last fri>
+All days except the final Friday of the month.
+</ifday>
+```
+
+---
 
 ## Day and Month Ranges
 
@@ -242,9 +371,17 @@ This is a wrap-around range for winter months.
 <ifday month in [may, jun, jul..sep]>
 This is visible in May, June, and the third quarter of the year.
 </ifday>
+
+<ifday (month in [nov..dec]) AND last fri>
+End-of-year Friday promo.
+</ifday>
+
+<ifday (month in [jun..aug]) AND (mon or tue)>
+Summer content on Mon/Tue, shorthand + range.
+</ifday>
 ```
 
------
+---
 
 ## Mixed Conditions
 
@@ -274,9 +411,17 @@ Visible if tomorrow is Friday.
 <ifday (yesterday AND weekday)>
 Visible if yesterday was a weekday.
 </ifday>
+
+<ifday (2nd monday) AND (month in [jan..mar])>
+Q1 content for the second Monday.
+</ifday>
+
+<ifday (last fri) OR (mon or tue)>
+Either the month’s final Friday, or early-week days.
+</ifday>
 ```
 
------
+---
 
 ## Tier 1 Additions Usage Examples
 
@@ -344,13 +489,25 @@ Visible only on weekends.
 </ifday>
 ```
 
------
+**Additional examples (new features):**
+
+```dokuwiki
+<ifday (day+1 == mon) AND (not fri)>
+Tomorrow is Monday and today is not Friday.
+</ifday>
+
+<ifday today is 2nd monday>
+Ordinal comparison with `today`.
+</ifday>
+```
+
+---
 
 ## Error Handling and Configuration
 
-- If your condition expression is invalid or unsafe, the plugin logs an error and, by default, **displays a visible warning box** on the page showing the error message and the original condition.
-- This visible error display can be toggled on/off in the plugin configuration (`show_errors` option) via the DokuWiki admin interface.
-- When disabled, errors will be logged silently without showing messages on the wiki pages.
+* If your condition expression is invalid or unsafe, the plugin logs an error and, by default, **displays a visible warning box** on the page showing the error message and the original condition.
+* This visible error display can be toggled on/off in the plugin configuration (`show_errors` option) via the DokuWiki admin interface.
+* When disabled, errors will be logged silently without showing messages on the wiki pages.
 
 Example error message style:
 
@@ -361,49 +518,51 @@ Example error message style:
 </div>
 ```
 
------
+---
 
 ## Summary of Supported Syntax
 
-| Feature             | Syntax Examples                                          | Description                                      |
-|---------------------|----------------------------------------------------------|--------------------------------------------------|
-| Equality            | `day == monday`, `day is fri`                            | Checks if current day equals specified day       |
-| Inequality          | `day != sunday`                                          | Checks if current day is not the specified day   |
-| Logical AND         | `weekday AND day != friday`, `weekday && day != fri`     | Combine conditions with AND logic                |
-| Logical OR          | `weekend OR day == monday`, `weekend or day == mon`      | Combine conditions with OR logic                 |
-| Negation            | `NOT weekday`, `NOT (day == saturday)`                   | Negates the condition                            |
-| Boolean checks      | `weekday`, `weekend`                                     | True if current day is a weekday or weekend      |
-| Boolean Day         | `monday`, `tuesday`, `wednesday`, etc                    | True if current day is that day                  |
-| Grouping            | `(weekday AND day != friday) OR weekend`                 | Use parentheses for complex logic                |
-| Day Abbreviations   | `day == mon`, `day is tue`                               | Supports 3-letter abbreviations for days         |
-| Relative Keywords   | `(tomorrow AND day == friday)`, `(yesterday AND weekday)` | Relative-day checks with comparisons             |
-| Day Ranges          | `day in [mon..fri]`, `day in [sat, sun, mon]`            | Checks if current day is in a list or range      |
-| Month Checks        | `month == december`, `month in [jun..aug]`               | Checks based on calendar month                   |
-| Month Ranges        | `month in [1..3]`, `month in [nov..jan, mar]`            | Checks if current month is in a list or range    |
-| Year Checks         | `year == 2025`                                           | Checks based on year                             |
-| Workday Aliases     | `workday`, `businessday`                                 | Alias for weekday (Mon–Fri)                      |
+| Feature           | Syntax Examples                                           | Description                                    |
+| ----------------- | --------------------------------------------------------- | ---------------------------------------------- |
+| Equality          | `day == monday`, `day is fri`                             | Checks if current day equals specified day     |
+| Inequality        | `day != sunday`                                           | Checks if current day is not the specified day |
+| Logical AND       | `weekday AND day != friday`, `weekday && day != fri`      | Combine conditions with AND logic              |
+| Logical OR        | `weekend OR day == monday`, `weekend or day == mon`       | Combine conditions with OR logic               |
+| Negation          | `NOT weekday`, `NOT (day == saturday)`                    | Negates the condition                          |
+| Boolean checks    | `weekday`, `weekend`                                      | True if current day is a weekday or weekend    |
+| Boolean Day       | `monday`, `tuesday`, `wednesday`, etc                     | True if current day is that day                |
+| Grouping          | `(weekday AND day != friday) OR weekend`                  | Use parentheses for complex logic              |
+| Day Abbreviations | `day == mon`, `day is tue`                                | Supports 3-letter abbreviations for days       |
+| Relative Keywords | `(tomorrow AND day == friday)`, `(yesterday AND weekday)` | Relative-day checks with comparisons           |
+| Day Ranges        | `day in [mon..fri]`, `day in [sat, sun, mon]`             | Checks if current day is in a list or range    |
+| Month Checks      | `month == december`, `month in [jun..aug]`                | Checks based on calendar month                 |
+| Month Ranges      | `month in [1..3]`, `month in [nov..jan, mar]`             | Checks if current month is in a list or range  |
+| Year Checks       | `year == 2025`                                            | Checks based on year                           |
+| Workday Aliases   | `workday`, `businessday`                                  | Alias for weekday (Mon–Fri)                    |
+| Boolean day shorthand    | `mon or tue`, `not mon`, `mon and tue`, `mon, tue` | No need for `day is`; supports `and`, `or`, `not`, commas |
+| Ordinal weekday-of-month | `2nd monday`, `last friday`, `5th tue`             | Optional `of month`; works with `today is …`, negation    |
 
------
+---
 
 ## Notes
 
-- The plugin evaluates conditions based on the **server’s current date** and time.
-- Logical operators (`AND`, `OR`, `NOT`) and comparison operators (`is`, `==`, `!=`) are **case-insensitive**.
-- Parentheses are supported for grouping and clarifying complex logic.
-- Invalid or unsafe expressions cause the condition to evaluate as false and produce an error message or log.
-- The plugin currently does **not support time-of-day comparisons**, only day/month/year-based logic.
-- Day names and abbreviations are normalized internally to ensure flexible matching.
+* The plugin evaluates conditions based on the **server’s current date** and time.
+* Logical operators (`AND`, `OR`, `NOT`) and comparison operators (`is`, `==`, `!=`) are **case-insensitive**.
+* Parentheses are supported for grouping and clarifying complex logic.
+* Invalid or unsafe expressions cause the condition to evaluate as false and produce an error message or log.
+* The plugin currently does **not support time-of-day comparisons**, only day/month/year-based logic.
+* Day names and abbreviations are normalized internally to ensure flexible matching.
 
------
+---
 
 ## Installation
 
-1.  Extract the `ifday` folder into your DokuWiki `lib/plugins/` directory.
-2.  Make sure the plugin is enabled (usually enabled by default).
-3.  Use `<ifday>` tags with conditions in your wiki pages as described above.
-4.  Configure error message visibility from **Admin → Configuration Settings → ifday → Show errors**.
+1. Extract the `ifday` folder into your DokuWiki `lib/plugins/` directory.
+2. Make sure the plugin is enabled (usually enabled by default).
+3. Use `<ifday>` tags with conditions in your wiki pages as described above.
+4. Configure error message visibility from **Admin → Configuration Settings → ifday → Show errors**.
 
------
+---
 
 ## Support
 

--- a/inc/ConditionEvaluator.php
+++ b/inc/ConditionEvaluator.php
@@ -41,6 +41,7 @@ class Ifday_ConditionEvaluator {
             $content = $contentElse;
         }
 
+        $info = []; // Dokuwiki renderer info array
         return [true, p_render('xhtml', p_get_instructions($content), $info), null];
     }
 
@@ -62,6 +63,14 @@ class Ifday_ConditionEvaluator {
             return null;
         }
 
+        // *** NEW: if the expression contains an ordinal/last weekday phrase,
+        // bail out so processOrdinalWeekdayOfMonth() can handle it first.
+        // Examples we want to avoid rewriting here:
+        //   "2nd monday", "last fri", "5th tue of month"
+        if (preg_match('/\b(?:\d+(?:st|nd|rd|th)|last)\s+[a-z]+(?:\s+of\s+month)?\b/i', $s)) {
+            return null;
+        }
+
         // Use your existing maps so we don't depend on a new utils API
         $abbr = Ifday_Utils::getDayAbbrMap();   // e.g. mon => monday
         $full = Ifday_Utils::getDays();         // ['monday', ... 'sunday']
@@ -78,6 +87,20 @@ class Ifday_ConditionEvaluator {
         foreach ($parts as $raw) {
             $tok = trim($raw);
             if ($tok === '') continue;
+
+            // allow ordinals like 1st/2nd/3rd/4th/5th and 'last'
+            // NOTE: We now bail earlier if an ordinal phrase exists, so this
+            // branch will rarely be used; keep it to avoid changing behavior.
+            if (preg_match('/^(?:\d+(?:st|nd|rd|th)|last)$/i', $tok)) {
+                $out[] = strtolower($tok);
+                continue;
+            }
+
+            // allow filler words for expressions like "2nd monday of month"
+            if (in_array(strtolower($tok), ['of','month'], true)) {
+                $out[] = strtolower($tok);
+                continue;
+            }
 
             // parentheses
             if ($tok === '(' || $tok === ')') { $out[] = $tok; continue; }
@@ -155,17 +178,27 @@ class Ifday_ConditionEvaluator {
      * @return array [bool success, string|bool result]
      */
     private function evaluateCondition(string $cond, ?DateTime $testDate = null): array {
-        // Check if a specific date is set via environment variable (from `withTestDate` wrapper)
-        $testDateStr = getenv('IFDAY_TEST_DATE');
-        if ($testDateStr) {
-            $now = new DateTime($testDateStr);
-        } elseif ($testDate !== null) {
-            // Fallback to the original test day parameter if a specific date isn't set
-            $now = $testDate;
+        // We use two "clocks":
+        //  - $nowDay:    per-row date (varies across the truth table week)
+        //  - $nowAnchor: snapshot base date from IFDAY_TEST_DATE if present;
+        //                used for month/year and (is) weekday/weekend tokens
+        //
+        // Rationale: tests expect week snapshots to keep month/year and
+        // “is weekday/weekend” anchored to the snapshot date, while
+        // day/today/tomorrow/yesterday/ordinals vary per row.
+
+        $envStr = getenv('IFDAY_TEST_DATE') ?: null;
+
+        if ($testDate !== null) {
+            $nowDay = $testDate;
+        } elseif ($envStr) {
+            $nowDay = new DateTime($envStr);
         } else {
-            // Default to the current date if no test date is provided
-            $now = new DateTime();
+            $nowDay = new DateTime();
         }
+
+        // Anchor prefers the environment date when provided
+        $nowAnchor = $envStr ? new DateTime($envStr) : $nowDay;
 
         // Pre-check for lone identifiers and disallow *uppercase* NOT applied to a lone identifier.
         // (lowercase 'not mon' is allowed and will be expanded by expandDayOnlySyntax)
@@ -188,7 +221,7 @@ class Ifday_ConditionEvaluator {
             }
         }
 
-        // Expand "mon or tue" style shorthand before any other normalization
+        // 1) first try day-only shorthand (pure cases)
         $maybeExpanded = $this->expandDayOnlySyntax($cond);
         if ($maybeExpanded !== null) {
             $cond = $maybeExpanded;
@@ -196,17 +229,24 @@ class Ifday_ConditionEvaluator {
 
         $cond = trim(preg_replace('/\s+/', ' ', $cond));
         $cond = str_replace(['"', '\''], '', $cond);
-
-        // Tolerate spaces in [ ... ] lists/ranges
         $cond = $this->normalizeBracketLists($cond);
+
+        // 2) Resolve "2nd monday", "last friday", etc. to 1/0  (per-row clock)
+        $cond = $this->processOrdinalWeekdayOfMonth($cond, $nowDay);
+
+        // 3) Now that ordinals are collapsed, try shorthand again for mixed cases like "2nd monday or tue"
+        $maybeExpanded2 = $this->expandDayOnlySyntax($cond);
+        if ($maybeExpanded2 !== null) {
+            $cond = $maybeExpanded2;
+        }
 
         // Process conditions in a specific order of precedence
         $cond = $this->processShorthand($cond);
-        $cond = $this->processDayComparisons($cond, $now);
-        $cond = $this->processDayRanges($cond, $now);
-        $cond = $this->processMonthComparisons($cond, $now);
-        $cond = $this->processMonthRanges($cond, $now);
-        $cond = $this->processYearComparisons($cond, $now);
+        $cond = $this->processDayComparisons($cond, $nowDay, $nowAnchor); // per-row for day; anchored for weekday/weekend tokens
+        $cond = $this->processDayRanges($cond, $nowDay);                  // per-row
+        $cond = $this->processMonthComparisons($cond, $nowAnchor);        // anchored
+        $cond = $this->processMonthRanges($cond, $nowAnchor);             // anchored
+        $cond = $this->processYearComparisons($cond, $nowAnchor);         // anchored
         $cond = $this->processLogicalOperators($cond);
 
         // Check for error tokens before final eval
@@ -246,12 +286,130 @@ class Ifday_ConditionEvaluator {
         return $cond;
     }
 
-    private function processDayComparisons(string $cond, DateTime $now): string {
-        $dayName = strtolower($now->format('l'));
+    private function processOrdinalWeekdayOfMonth(string $cond, DateTime $now): string {
+        $dayMap = Ifday_Utils::getDayAbbrMap();  // mon->monday, ...
+        $days   = Ifday_Utils::getDays();        // ['monday',..., 'sunday']
+
+        // Helper: full day -> ISO-8601 index (Mon=1..Sun=7)
+        $dayIndex = function(string $fullDay): ?int {
+            static $map = [
+                'monday'=>1,'tuesday'=>2,'wednesday'=>3,'thursday'=>4,
+                'friday'=>5,'saturday'=>6,'sunday'=>7
+            ];
+            return $map[$fullDay] ?? null;
+        };
+
+        // Helper: nth occurrence day-of-month (or null if it doesn't exist)
+        $nthDom = function(DateTime $base, int $isoDow, int $n): ?int {
+            $y = (int)$base->format('Y');
+            $m = (int)$base->format('n');
+            $first = (clone $base)->setDate($y, $m, 1);
+            $firstIso = (int)$first->format('N');            // Mon=1..Sun=7
+            $delta = ($isoDow - $firstIso + 7) % 7;
+            $firstHit = 1 + $delta;                           // first target weekday in month
+            $dom = $firstHit + 7 * ($n - 1);
+            $daysInMonth = (int)$first->format('t');
+            return ($dom >= 1 && $dom <= $daysInMonth) ? $dom : null;
+        };
+
+        // Helper: last occurrence day-of-month
+        $lastDom = function(DateTime $base, int $isoDow): int {
+            $y = (int)$base->format('Y');
+            $m = (int)$base->format('n');
+            $last = (clone $base)->setDate($y, $m, (int)$base->format('t'));
+            $lastIso = (int)$last->format('N');
+            $deltaBack = ($lastIso - $isoDow + 7) % 7;
+            return (int)$last->format('j') - $deltaBack;
+        };
+
+        // Core evaluator for a phrase like "2nd monday" or "last fri"
+        $evalPhrase = function(string $phrase) use ($dayMap, $days, $dayIndex, $nthDom, $lastDom, $now) {
+            $phrase = strtolower(trim($phrase));
+            // normalize multiple spaces (e.g., "2nd   monday  of month")
+            $phrase = preg_replace('/\s+/', ' ', $phrase);
+            // strip optional " of month"
+            $phrase = preg_replace('/\s+of\s+month$/', '', $phrase);
+
+            if (!preg_match('/^(?<ord>\d+(?:st|nd|rd|th)|last)\s+(?<day>[a-z]+)$/i', $phrase, $mm)) {
+                return null; // not our pattern
+            }
+
+            $ordRaw = strtolower($mm['ord']);
+            $dayRaw = strtolower($mm['day']);
+            $full   = $dayMap[$dayRaw] ?? $dayRaw;
+            if (!in_array($full, $days, true)) {
+                return self::TOKEN_INVALID_DAY . ':' . $dayRaw;
+            }
+
+            $iso = $dayIndex($full); // 1..7
+            if ($iso === null) return self::TOKEN_INVALID_DAY . ':' . $dayRaw;
+
+            $todayDom = (int)$now->format('j');
+            $todayIso = (int)$now->format('N');
+
+            if ($ordRaw === 'last') {
+                $targetDom = $lastDom($now, $iso);
+            } else {
+                // convert 1st/2nd/3rd/4th/5th -> 1..5
+                $n = (int)preg_replace('/(st|nd|rd|th)$/', '', $ordRaw);
+                $targetDom = $nthDom($now, $iso, $n);
+                if ($targetDom === null) {
+                    // "5th monday" in a month with only four Mondays → always false
+                    return '0';
+                }
+            }
+
+            // match iff today's iso and dom match the computed occurrence
+            return ($todayIso === $iso && $todayDom === $targetDom) ? '1' : '0';
+        };
+
+        // (A) today/day comparisons: "(today|day) is [not|==|!=] <ord day>"
+        $cond = preg_replace_callback(
+            '/\b(today|day)\s+(?:is\s+(not\s+)?|([!=]=)\s*)((?:\d+(?:st|nd|rd|th)|last)\s+[a-z]+(?:\s+of\s+month)?)\b/i',
+            function($m) use ($evalPhrase) {
+                $neg = !empty($m[2]);
+                $op  = $m[3] ?: '==';
+                $val = $evalPhrase($m[4]);
+                if ($val === null) return $m[0];          // not our pattern; leave untouched
+                if (str_starts_with($val, self::TOKEN_INVALID_DAY)) return $val;
+                $bool = ($val === '1');
+                $res  = ($op === '==') ? $bool : !$bool;   // today == phrase  → bool ; today != phrase → !bool
+                return ($neg ? !$res : $res) ? '1' : '0';
+            },
+            $cond
+        );
+
+        // (B) bare (or negated) ordinal phrases: "[not] <ord day>"
+        $cond = preg_replace_callback(
+            '/\b(?:not\s+)?((?:\d+(?:st|nd|rd|th)|last)\s+[a-z]+(?:\s+of\s+month)?)\b/i',
+            function($m) use ($cond, $evalPhrase) {
+                // respect preceding 'not ' if present
+                $full = $m[0];
+                $hasNot = (bool)preg_match('/^\s*not\s+/i', $full);
+                // extract the phrase without 'not '
+                $phrase = preg_replace('/^\s*not\s+/i', '', $full);
+                $val = $evalPhrase($phrase);
+                if ($val === null) return $m[0];                // not our pattern
+                if (str_starts_with($val, Ifday_ConditionEvaluator::TOKEN_INVALID_DAY)) return $val;
+                $bool = ($val === '1');
+                return ($hasNot ? !$bool : $bool) ? '1' : '0';
+            },
+            $cond
+        );
+
+        return $cond;
+    }
+
+    private function processDayComparisons(string $cond, DateTime $now, ?DateTime $anchor = null): string {
+        $anchor = $anchor ?? $now;
+
+        $dayNameNow = strtolower($now->format('l'));          // per-row clock
+        $dayNameAnchor = strtolower($anchor->format('l'));    // anchored clock
+
         $dayMap = Ifday_Utils::getDayAbbrMap();
         $days = Ifday_Utils::getDays();
 
-        // today|tomorrow|yesterday comparisons -> 1/0
+        // today|tomorrow|yesterday comparisons -> 1/0 (per-row)
         $cond = preg_replace_callback(
             '/\b(today|tomorrow|yesterday)\s+(?:is\s+(not\s+)?|([!=]=)\s*)([a-z]+)\b/i',
             function($m) use ($now, $dayMap, $days) {
@@ -270,7 +428,7 @@ class Ifday_ConditionEvaluator {
             }, $cond
         );
 
-        // day±N ==/!= <day> or bare "day±N"
+        // day±N ==/!= <day> or bare "day±N" (per-row)
         $cond = preg_replace_callback(
             '/\bday\s*([+-]\d+)(?:\s*([!=]=)\s*([a-z]+))?\b/i',
             function($m) use ($now, $dayMap, $days) {
@@ -290,50 +448,50 @@ class Ifday_ConditionEvaluator {
             }, $cond
         );
 
-        // "is (not) weekday/weekend"
+        // "is (not) weekday/weekend/workday/businessday"  — anchored to snapshot
         $cond = preg_replace_callback(
             '/\bis\s+(not\s+)?(weekday|weekend|workday|businessday)\b/i',
-            function($m) use ($dayName) {
+            function($m) use ($dayNameAnchor) {
                 $neg = !empty($m[1]);
                 $tok = strtolower($m[2]);
-                $isWeekend = in_array($dayName, ['saturday', 'sunday'], true);
+                $isWeekend = in_array($dayNameAnchor, ['saturday', 'sunday'], true);
                 $isWeekday = !$isWeekend;
                 $val = in_array($tok, ['weekday','workday','businessday'], true) ? $isWeekday : $isWeekend;
                 return ($neg ? !$val : $val) ? '1' : '0';
             }, $cond
         );
 
-        // "day is X" / "day is not X"
+        // "day is X" / "day is not X" (per-row)
         $cond = preg_replace_callback(
             '/\bday\s+is\s+(not\s+)?([a-z]+)\b/i',
-            function($m) use ($dayName, $dayMap, $days) {
+            function($m) use ($dayNameNow, $dayMap, $days) {
                 $negate = !empty($m[1]);
                 $inputDay = strtolower($m[2]);
                 $fullDay = $dayMap[$inputDay] ?? $inputDay;
                 if (!in_array($fullDay, $days, true)) return self::TOKEN_INVALID_DAY . ':' . $inputDay;
-                $result = ($dayName === $fullDay);
+                $result = ($dayNameNow === $fullDay);
                 return ($negate ? !$result : $result) ? '1' : '0';
             }, $cond
         );
 
-        // "day ==/!= X"
+        // "day ==/!= X" (per-row)
         $cond = preg_replace_callback(
             '/\bday\s*([!=]=)\s*([a-z]+)\b/i',
-            function($m) use ($dayName, $dayMap, $days) {
+            function($m) use ($dayNameNow, $dayMap, $days) {
                 $op = $m[1];
                 $inputDay = strtolower($m[2]);
                 $inputDay = $dayMap[$inputDay] ?? $inputDay;
                 if (!in_array($inputDay, $days, true)) return self::TOKEN_INVALID_DAY . ':' . $inputDay;
-                $result = ($op === '==') ? ($dayName === $inputDay) : ($dayName !== $inputDay);
+                $result = ($op === '==') ? ($dayNameNow === $inputDay) : ($dayNameNow !== $inputDay);
                 return $result ? '1' : '0';
             }, $cond
         );
 
-        // Standalone tokens
-        $isWeekend = in_array($dayName, ['saturday', 'sunday'], true);
-        $isWeekday = !$isWeekend;
-        $cond = preg_replace('/\b(weekday|workday|businessday)\b/i', $isWeekday ? '1' : '0', $cond);
-        $cond = preg_replace('/\bweekend\b/i', $isWeekend ? '1' : '0', $cond);
+        // Standalone tokens — anchored to snapshot
+        $isWeekendA = in_array($dayNameAnchor, ['saturday', 'sunday'], true);
+        $isWeekdayA = !$isWeekendA;
+        $cond = preg_replace('/\b(weekday|workday|businessday)\b/i', $isWeekdayA ? '1' : '0', $cond);
+        $cond = preg_replace('/\bweekend\b/i', $isWeekendA ? '1' : '0', $cond);
 
         return $cond;
     }

--- a/tests/tests/snapshots.php
+++ b/tests/tests/snapshots.php
@@ -77,6 +77,112 @@ return [
         ]
     ],
 
+    // === Ordinal/Last Weekday tests ===
+
+    [
+        'date' => '2025-02-14', // Monday, week of 2025-02-10..16
+        'name' => 'Week of February 14, 2025',
+        'tests' => [
+            ['condition' => '2nd monday',   'currentDays' => ['mon']],
+            ['condition' => '2nd mon',      'currentDays' => ['mon']],
+            ['condition' => 'last friday',  'currentDays' => []],      // last Friday (Feb 28) is not in this week
+            ['condition' => 'last fri',     'currentDays' => []],      // last Friday (Feb 28) is not in this week
+            ['condition' => '5th monday',   'currentDays' => []],      // Feb 2025 has only 4 Mondays
+            ['condition' => '5th mon',      'currentDays' => []],      // Feb 2025 has only 4 Mondays
+        ]
+    ],
+
+    [
+        'date' => '2025-02-28', // Monday, week of 2025-02-24..03-02
+        'name' => 'Week of February 28, 2025',
+        'tests' => [
+            ['condition' => 'last friday',  'currentDays' => ['fri']],
+            ['condition' => 'last fri',     'currentDays' => ['fri']],
+            ['condition' => 'last monday',  'currentDays' => ['mon']],
+            ['condition' => 'last mon',     'currentDays' => ['mon']],
+         ]
+    ],
+
+    [
+        /* March 2025 has five Mondays */
+        'date' => '2025-03-31', // Monday, week of 2025-03-31..04-06
+        'name' => 'Week of March 31, 2025',
+        'tests' => [
+            ['condition' => '5th monday',   'currentDays' => ['mon']],
+            ['condition' => '5th mon',      'currentDays' => ['mon']],
+            ['condition' => 'last monday',  'currentDays' => ['mon']],
+            ['condition' => 'last mon',     'currentDays' => ['mon']],
+            ['condition' => '5th friday',   'currentDays' => []],      // March 2025 has only 4 Fridays
+            ['condition' => '5th fri',      'currentDays' => []],
+        ]
+    ],
+
+    [
+        /* November 2025 has five Saturdays */
+        'date' => '2025-11-29', // Monday, week of 2025-11-24..11-30
+        'name' => 'Week of November 29, 2025',
+        'tests' => [
+            ['condition' => 'last saturday',    'currentDays' => ['sat']],
+            ['condition' => 'last sat',         'currentDays' => ['sat']],
+            ['condition' => '5th saturday',     'currentDays' => ['sat']],
+            ['condition' => '5th sat',          'currentDays' => ['sat']],
+        ]
+    ],
+
+    [
+        /* January 2026 has five Fridays */
+        'date' => '2026-01-30', // Monday, week of 2026-01-26..02-01
+        'name' => 'Week of January 30, 2026',
+        'tests' => [
+            ['condition' => '5th friday',   'currentDays' => ['fri']],
+            ['condition' => '5th fri',      'currentDays' => ['fri']],
+            ['condition' => 'last friday',  'currentDays' => ['fri']],
+            ['condition' => 'last fri',     'currentDays' => ['fri']],
+        ]
+    ],
+
+    [
+        'date' => '2025-07-10', // Monday, week of 2025-07-07..07-13
+        'name' => 'Week of July 10, 2025',
+        'tests' => [
+            ['condition' => '2nd thursday', 'currentDays' => ['thu']],
+            ['condition' => '2nd thu',      'currentDays' => ['thu']],
+        ]
+    ],
+
+    [
+        'date' => '2025-07-31', // Monday, week of 2025-07-28..08-03
+        'name' => 'Week of July 31, 2025',
+        'tests' => [
+            ['condition' => 'last thursday',    'currentDays' => ['thu']],
+            ['condition' => 'last thu',         'currentDays' => ['thu']],
+            ['condition' => '5th thursday',     'currentDays' => ['thu']],
+            ['condition' => '5th thu',          'currentDays' => ['thu']],
+        ]
+    ],
+
+    [
+        'date' => '2025-12-15', // Monday, week of 2025-12-15..12-21
+        'name' => 'Week of December 15, 2025',
+        'tests' => [
+            ['condition' => '3rd monday',   'currentDays' => ['mon']],
+            ['condition' => '3rd mon',      'currentDays' => ['mon']],
+        ]
+    ],
+
+    [
+        'date' => '2025-03-31', // Monday, week of 2025-03-31..04-06
+        'name' => 'Week of March 31, 2025',
+        'tests' => [
+            ['condition' => '5th monday',   'currentDays' => ['mon']],
+            ['condition' => '5th mon',      'currentDays' => ['mon']],
+            ['condition' => 'last monday',  'currentDays' => ['mon']],
+            ['condition' => 'last mon',     'currentDays' => ['mon']],
+            ['condition' => '5th friday',   'currentDays' => []],    // March 2025 has only 4 Fridays
+            ['condition' => '5th fri',      'currentDays' => []],
+        ]
+    ],
+
     [
         'date' => '2025-07-15', // Tuesday
         'name' => 'July 2025 (A)',


### PR DESCRIPTION
**Summary**
Adds two user-facing features and updates documentation/examples without changing existing behavior.

**What’s new**

* **Ordinal weekday-of-month**: support for `1st/2nd/3rd/4th/5th <weekday>` and `last <weekday>` (e.g., `2nd monday`, `last fri`, `5th tue`). Works with comparisons and negation: `today is 2nd monday`, `not last fri`, optional `of month`.
* **Day-only boolean shorthand**: natural expressions without `day is …`:
  `mon or tue`, `mon,tue`, `mon and tue`, `not mon`, `(mon and wed) or fri`.

**Implementation notes**

* New `processOrdinalWeekdayOfMonth()` handles nth/last logic (including `today is …` and `not …`).
* `expandDayOnlySyntax()` skips ordinal phrases to avoid mis-rewrites; second pass catches mixed cases.
* `normalizeBracketLists()` tidies `[...]` spacing; error tokens for invalid day/month and incomplete ranges preserved.
* Safety checks maintained (strict token whitelist before `eval`).

**Compatibility**

* Backward-compatible; existing syntax unaffected.
* Nonexistent occurrences (e.g., `5th monday` in a 4-Monday month) evaluate to `false`.
* No config or public API changes.

**Tests**

* Truth tables expanded for ordinal phrases, shorthand combos, and `today/tomorrow/yesterday` comparisons.
* Snapshots for months/weeks updated; all tests pass locally.

**Examples**

```dokuwiki
<ifday 2nd monday> Team stand-up today. </ifday>
<ifday last fri> Month-end reminder. </ifday>
<ifday mon or tue> Early-week promo. </ifday>
<ifday not mon> Not Monday content. </ifday>
<ifday today is 2nd monday> Special notice. </ifday>
```
