### PR TITLE
fix: ordinals weren't working properly if you had them as booleans

### DIFF
--- a/tests/tests/snapshots.php
+++ b/tests/tests/snapshots.php
@@ -165,6 +165,7 @@ return [
         'date' => '2025-12-15', // Monday, week of 2025-12-15..12-21
         'name' => 'Week of December 15, 2025',
         'tests' => [
+            ['condition' => '1st monday',   'currentDays' => []],
             ['condition' => '3rd monday',   'currentDays' => ['mon']],
             ['condition' => '3rd mon',      'currentDays' => ['mon']],
         ]


### PR DESCRIPTION
Day ordinals weren't working correctly if used as a boolean.

This would fail with a safety check:
```
<ifday 1st friday>
...
```

This error: 
```
ifday plugin error evaluating condition: "1st friday" Details: 
Safety check failed for processed condition '1st friday'
```